### PR TITLE
chore: use tagpr for release

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -9,3 +9,18 @@ jobs:
     uses: ./.github/workflows/wf-test-all-golibs.yml
     with:
       go-cache: true
+
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        id: app-token
+        with:
+          app-id: 2119989
+          private-key: ${{ secrets.BOT_GITHUB_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+      - uses: Songmu/tagpr@7191605433b03e11b313dbbc0efb80185170de4b # v1.9.0
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
We use tagpr to list unreleased PRs and assist in version decisions.

Similar example:
- https://github.com/mackerelio-labs/mcp-server/pull/23