### PR TITLE
chore: fix docker image repository name

### DIFF
--- a/distributions/otelcol-mackerel/.goreleaser.yaml
+++ b/distributions/otelcol-mackerel/.goreleaser.yaml
@@ -35,8 +35,8 @@ dockers_v2:
     ids:
       - otelcol-mackerel-linux
     images:
-      - mackerelio/opentelemetry-collector-mackerel/otelcol-mackerel
-      - gcr.io/mackerelio/opentelemetry-collector-mackerel/otelcol-mackerel
+      - mackerel/otelcol-mackerel
+      - ghcr.io/mackerelio/opentelemetry-collector-mackerel/otelcol-mackerel
     tags:
       - "{{.Version}}"
       - latest


### PR DESCRIPTION
There are two errors in the repository name for the otelcol-mackerel image:

- Organization name in DockerHub is wrong.
- ghr.io and ghcr.io are mixed up. We want to push to the GitHub Container Repository (ghcr.io).

This pull request fixes the issue above.

You can confirm that the Docker Hub repository specified here exists via the following URL: https://hub.docker.com/repository/docker/mackerel/otelcol-mackerel/general

