### PR TITLE
chore: set git author when push monorepo release tags

### DIFF
--- a/.github/workflows/on-push-beta-version-tag.yml
+++ b/.github/workflows/on-push-beta-version-tag.yml
@@ -51,6 +51,10 @@ jobs:
       - name: Verify
         run: |
           go tool multimod verify
+      - name: Set git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
       - name: Create Tags
         run: |
           set -e


### PR DESCRIPTION
update-multimod-tags workflow failed:

> unable to tag modules: git tag failed for exporter/mackerelotlpexporter/v0.2.0: unable to create tag: "Committer identity unknown\n\n*** Please tell me who you are.\n\nRun\n\n  git config --global user.email \"you@example.com\"\n  git config --global user.name \"Your Name\"\n\nto set your account's default identity.\nOmit --global to set the identity only in this repository.\n\nfatal: unable to auto-detect email address (got 'runner@runnervmwhb2z.(none)')\n": exit status 128

https://github.com/mackerelio/opentelemetry-collector-mackerel/actions/runs/18931041133/job/54047860000

Setting the git user resolves this issue.
