### PR TITLE
chore: set GH_TOKEN to gh command

### DIFF
--- a/.github/workflows/on-push-beta-version-tag.yml
+++ b/.github/workflows/on-push-beta-version-tag.yml
@@ -29,6 +29,8 @@ jobs:
         name: Get the previous version tag
         run: |
           gh release list --json tagName,isLatest --jq '.[] | select(.isLatest) | "PREVIOUS_TAG=" + .tagName' >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Run OpenTelemetry Collector Builder
         run: |
           go generate .


### PR DESCRIPTION
release-otelcol-mackerel workflow failed:

> gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}

https://github.com/mackerelio/opentelemetry-collector-mackerel/actions/runs/18931041133/job/54047859983

Setting `GH_TOKEN` environment variable resolves this issue.