### PR TITLE
chore: set GITHUB_TOKEN to goreleaser command

### DIFF
--- a/.github/workflows/on-push-beta-version-tag.yml
+++ b/.github/workflows/on-push-beta-version-tag.yml
@@ -42,6 +42,7 @@ jobs:
         env:
           GORELEASER_CURRENT_TAG: ${{ github.sha }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev-version-tag.outputs.PREVIOUS_TAG }}
+          GITHUB_TOKEN: ${{ github.token }}
 
   update-multimod-tags:
     runs-on: ubuntu-latest


### PR DESCRIPTION
release-otelcol-mackerel workflow failed:

>   ⨯ release failed after 0s                          error=missing GITHUB_TOKEN, GITLAB_TOKEN and GITEA_TOKEN

https://github.com/mackerelio/opentelemetry-collector-mackerel/actions/runs/18931937957/job/54050364633

Setting `GITHUB_TOKEN` environment variable resolves this issue.