### PR TITLE
chore: change GORELEASER_CURRENT_TAG value from sha to tag name

### DIFF
--- a/.github/workflows/on-push-beta-version-tag.yml
+++ b/.github/workflows/on-push-beta-version-tag.yml
@@ -40,7 +40,7 @@ jobs:
           go tool goreleaser release
         working-directory: distributions/otelcol-mackerel
         env:
-          GORELEASER_CURRENT_TAG: ${{ github.sha }}
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
           GORELEASER_PREVIOUS_TAG: ${{ steps.prev-version-tag.outputs.PREVIOUS_TAG }}
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
release-otelcol-mackerel workflow failed:

```
git state                                      commit=5fe03c119b6a4e421d7746ccb0d8ad450c8dfe44 branch=HEAD current_tag=5fe03c119b6a4e421d7746ccb0d8ad450c8dfe44 previous_tag=v0.1.0 dirty=false
  ⨯ release failed after 0s                          error=git tag 5fe03c119b6a4e421d7746ccb0d8ad450c8dfe44 was not made against commit 5fe03c119b6a4e421d7746ccb0d8ad450c8dfe44
```

https://github.com/mackerelio/opentelemetry-collector-mackerel/actions/runs/18932474603/job/54051889729

Changing GORELEASER_CURRENT_TAG value from sha to tag name resolves this issue.

cf.) https://docs.github.com/ja/actions/reference/workflows-and-actions/contexts#github-context