### PR TITLE
chore: disable docker SBOM attestations in GoReleaser

### DIFF
--- a/distributions/otelcol-mackerel/.goreleaser.yaml
+++ b/distributions/otelcol-mackerel/.goreleaser.yaml
@@ -70,6 +70,7 @@ dockers_v2:
     platforms:
       - linux/amd64
       - linux/arm64
+    sbom: false
 # monorepo setting is not available in GoReleaser free edition,
 # which means that running goreleaser with including monorepo tags will result in unintended version names.
 # The workaround is setting custom tags via `GORELEASER_CURRENT_TAG` and `GORELEASER_PREVIOUS_TAG` environment value.


### PR DESCRIPTION
release-otelcol-mackerel workflow failed:

```
  ⨯ release failed after 7m56s                       error=docker images (v2): failed to publish artifacts: exit status 1 args=docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/***/opentelemetry-collector-mackerel/otelcol-mackerel:0.2.0 -t ghcr.io/***/opentelemetry-collector-mackerel/otelcol-mackerel:latest -t mackerel/otelcol-mackerel:0.2.0 -t mackerel/otelcol-mackerel:latest --push --attest=type=sbom --iidfile=id.txt . id=otelcol-mackerel
    output=
    │ ERROR: failed to build: Attestation is not supported for the docker driver.
    │ Switch to a different driver, or turn on the containerd image store, and try again.
    │ Learn more at https://docs.docker.com/go/attestations/
```

https://github.com/mackerelio/opentelemetry-collector-mackerel/actions/runs/18936319354/job/54063941749

The Docker driver included in GitHub Actions runners does not seem to support attestation, so I removed the SBOM configuration.
