### PR TITLE
chore: refine renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+  "extends": ["config:recommended"],
+  "ocb": { "managerFilePatterns": ["/^distributions/.*/manifest\\.yaml$/"] },
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["go"],
+      "groupName": "go.opentelemetry.io/collector",
+      "matchPackageNames": ["/^go.opentelemetry.io/collector/"]
+    },
+    {
+      "matchManagers": ["ocb"],
+      "matchSourceUrls": [
+        "https://github.com/open-telemetry/opentelemetry-collector",
+        "https://github.com/open-telemetry/opentelemetry-collector-contrib"
+      ],
+      "groupName": "opentelemetry-collector upstream dependencies"
+    }
+  ],
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
We refine the renovate config for the following purposes:

- Grouping dependency updates in monorepos
- Upgrade components of OpenTelemetry Collector built with ocb
- Run `go mod tidy` to update indirect dependencies

We verified the config file by running renovate locally:

```console
$ npx renovate --platform=local
 INFO: Repository started (repository=local)
       "renovateVersion": "41.169.3"
 INFO: Dependency extraction complete (repository=local)
       "stats": {
         "managers": {
           "dockerfile": {"fileCount": 1, "depCount": 1},
           "github-actions": {"fileCount": 5, "depCount": 33},
           "gomod": {"fileCount": 3, "depCount": 488},
           "ocb": {"fileCount": 2, "depCount": 41}
         },
         "total": {"fileCount": 11, "depCount": 563}
       }
 WARN: GitHub token is required for some dependencies (repository=local)
       "githubDeps": [
         "actions/checkout",
         "actions/setup-go",
         "docker/setup-qemu-action",
         "docker/setup-buildx-action",
         "docker/login-action",
         "actions/create-github-app-token",
         "Songmu/tagpr",
         "golangci/golangci-lint-action",
         "go"
       ]
 INFO: Repository finished (repository=local)
       "cloned": undefined,
       "durationMs": 188008,
       "result": undefined,
       "status": undefined,
       "enabled": undefined,
       "onboarded": undefined
 INFO: Renovate was run at log level "info". Set LOG_LEVEL=debug in environment variables to see extended debug logs.
```