### PR TITLE
chore: fix release notes format

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,3 +6,10 @@ changelog:
     - title: Base opentelemetry-collector libraries updates
       labels:
         - upgrade-otelcol-libs
+    - title: New features/enhancements
+      labels:
+        - major
+        - minor
+    - title: Other changes
+      labels:
+        - '*'


### PR DESCRIPTION
Under the current release note settings, changes without the `upgrade-otelcol-libs` label will not appear in the release notes.

> <img width="824" height="197" alt="スクリーンショット 2025-11-11 18 16 30" src="https://github.com/user-attachments/assets/a8c13745-e8f7-4e51-a674-ba4545351493" />

This pull request fixes the issue. All changes will be displayed in three categories.

cf.) https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes