### PR TITLE
chore: Issue template for component bundle request

### DIFF
--- a/.github/ISSUE_TEMPLATE/component-bundle-request.yaml
+++ b/.github/ISSUE_TEMPLATE/component-bundle-request.yaml
@@ -1,11 +1,13 @@
-name: 
+name: "Component Bundle Request for otelcol-mackerel"
 description: Request to bundle a OpenTelemetry Collector component into otelcol-mackerel disto.
 title: "[otelcol-mackerel] Component Bundle Request: <component name>"
+assignees:
+  - "@mackerelio/mackerel-o11y-team"
 body:
   - type: input
     id: package
     attributes:
-      label: Package path of the component
+      label: Package path of the componen
       description: Please specify the fully qualified Go package path for the OpenTelemetry Collector component you wish to add.
       placeholder: github.com/open-telemetry/opentelemetry-collector-contrib/processor/foo
     validations:


### PR DESCRIPTION
otelcol-mackerel distribution already bundles several potentially useful components. However, some users may still want to use components that are not yet bundled.

This pull request prepares an issue template to enable users to submit bundle requests.

<img width="1086" height="585" alt="スクリーンショット 2025-11-25 14 56 30" src="https://github.com/user-attachments/assets/5aff3225-407a-475d-b853-710e6ca169b2" />
