### PR TITLE
feat: read API_KEY from systemd-creds

### DIFF
--- a/distributions/otelcol-mackerel/otelcol-mackerel.service
+++ b/distributions/otelcol-mackerel/otelcol-mackerel.service
@@ -3,6 +3,7 @@ Description=Mackerel OpenTelemetry Collector
 After=network.target
 
 [Service]
+LoadCredentialEncrypted=mackerel-apikey
 EnvironmentFile=-/etc/otelcol-mackerel/otelcol-mackerel.conf
 ExecStart=/usr/bin/otelcol-mackerel $OTELCOL_MACKEREL_OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID

--- a/exporter/mackerelotlpexporter/README.md
+++ b/exporter/mackerelotlpexporter/README.md
@@ -40,3 +40,9 @@ service:
 ```
 
 Set the Mackerel writable API key in the `MACKEREL_APIKEY` environment variable and run the OpenTelemetry Collector.
+
+Or systemd-creds
+
+```sh
+echo $MACKEREL_APIKEY | sudo systemd-creds encrypt --name mackerel-apikey - /etc/credstore.encrypted/mackerel-apikey
+```

--- a/exporter/mackerelotlpexporter/config.go
+++ b/exporter/mackerelotlpexporter/config.go
@@ -3,6 +3,7 @@ package mackerelotlpexporter
 import (
 	"errors"
 	"os"
+	"path/filepath"
 
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
@@ -44,7 +45,22 @@ func (cfg *Config) mackerelApiKey() (configopaque.String, error) {
 		return configopaque.String(v), nil
 	} else if v := os.Getenv("MACKEREL_API_KEY"); v != "" {
 		return configopaque.String(v), nil
+	} else if v, err := readCredentialFrom("mackerel-apikey"); err == nil {
+		return configopaque.String(v), nil
 	} else {
 		return "", errors.New("Mackerel API key must be specified") //nolint:staticcheck // Mackerel is proper noun
 	}
+}
+
+func readCredentialFrom(name string) (string, error) {
+	dir := os.Getenv("CREDENTIALS_DIRECTORY")
+	if dir == "" {
+		return "", os.ErrNotExist
+	}
+	file := filepath.Join(dir, name)
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }

--- a/exporter/mackerelotlpexporter/config_test.go
+++ b/exporter/mackerelotlpexporter/config_test.go
@@ -1,9 +1,12 @@
 package mackerelotlpexporter
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Validate(t *testing.T) {
@@ -27,6 +30,16 @@ func TestConfig_Validate(t *testing.T) {
 		cfg := &Config{}
 		t.Setenv("MACKEREL_APIKEY", "dummyapikey")
 		t.Setenv("MACKEREL_API_KEY", "dummyapikey")
+		assert.NoError(t, cfg.Validate())
+	})
+	t.Run("valid if Mackerel API key is provided via systemd-creds", func(t *testing.T) {
+		cfg := &Config{}
+		dir := t.TempDir()
+		t.Setenv("CREDENTIALS_DIRECTORY", dir)
+		file := filepath.Join(dir, "mackerel-apikey")
+		err := os.WriteFile(file, []byte("dummyapikey"), 0600)
+		require.NoError(t, err)
+
 		assert.NoError(t, cfg.Validate())
 	})
 	t.Run("invalid if no Mackerel API keys are provided", func(t *testing.T) {


### PR DESCRIPTION
[Systemd's manual](https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html) describes:

> Note that environment variables are not suitable for passing secrets (such as passwords, key material, …) to service processes. Environment variables set for a unit are exposed to unprivileged clients via D-Bus IPC, and generally not understood as being data that requires protection. Moreover, environment variables are propagated down the process tree, including across security boundaries (such as setuid/setgid executables), and hence might leak to processes that should not have access to the secret data. Use LoadCredential=, LoadCredentialEncrypted= or SetCredentialEncrypted= (see below) to pass data to unit processes securely.

But ...

- *LoadCredentialEncrypted=* was added in systemd 250
- If *LoadCredentialEncrypted=* is provided in the unit, it can't start without specified credential file