### PR TITLE
chore: remove working-directory input from setup-go because it does not exist

### DIFF
--- a/.github/workflows/wf-test-all-golibs.yml
+++ b/.github/workflows/wf-test-all-golibs.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: ${{ inputs.go-cache }}
-          working-directory: ${{ matrix.working-directory }}
       - uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
           args: --timeout=10m
@@ -39,7 +38,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: ${{ inputs.go-cache }}
-          working-directory: ${{ matrix.working-directory }}
       - name: Run Go tests
         run: |
           set -o pipefail

--- a/.github/workflows/wf-test-golib.yml
+++ b/.github/workflows/wf-test-golib.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: ${{ inputs.go-cache }}
-          working-directory: ${{ inputs.working-directory }}
       - uses: golangci/golangci-lint-action@e7fa5ac41e1cf5b7d48e45e42232ce7ada589601 # v9.1.0
         with:
           args: --timeout=10m


### PR DESCRIPTION
Warnings were raised saying that setup-go does not have `working-directory` input. Since it doesn’t exist, I removed it.

<img width="1166" height="798" alt="スクリーンショット 2025-12-01 15 23 46" src="https://github.com/user-attachments/assets/dc9dc52a-b74b-4ff1-b9ed-80e3ee22672a" />
