### PR TITLE
mackerelotlpexporter: do not return an error on Validate()

### DIFF
--- a/exporter/mackerelotlpexporter/config.go
+++ b/exporter/mackerelotlpexporter/config.go
@@ -30,9 +30,14 @@ func (cfg *Config) Validate() error {
 	if err := cfg.RetryConfig.Validate(); err != nil {
 		return err
 	}
-	if _, err := cfg.mackerelApiKey(); err != nil {
-		return err
-	}
+	// Generally, a deb package should successfully start the service it provides upon installation.
+	// For now, this exporter needs an API key which prevents us from adhering to this rule.
+	//
+	// However, Validate() should not return an error.
+	// If it does, the collector process will exit,
+	// and systemd will then attempt to restart the failed process repeatedly.
+	// In this scenario, since the error cannot be resolved due to the missing API key,
+	// the unit eventually reach its start limit.
 	return nil
 }
 

--- a/exporter/mackerelotlpexporter/config_test.go
+++ b/exporter/mackerelotlpexporter/config_test.go
@@ -29,8 +29,8 @@ func TestConfig_Validate(t *testing.T) {
 		t.Setenv("MACKEREL_API_KEY", "dummyapikey")
 		assert.NoError(t, cfg.Validate())
 	})
-	t.Run("invalid if no Mackerel API keys are provided", func(t *testing.T) {
+	t.Run("valid if no Mackerel API keys are provided", func(t *testing.T) {
 		cfg := &Config{}
-		assert.Error(t, cfg.Validate())
+		assert.NoError(t, cfg.Validate())
 	})
 }


### PR DESCRIPTION
I wrote code comments

https://github.com/mackerelio/opentelemetry-collector-mackerel/blob/b4c18180c70cef55ff581660fee1c48028ec6fa2/exporter/mackerelotlpexporter/config.go#L33-L40