### PR TITLE
fix: fixed the issue where default batch settings of mackerelotlp exporter were not applied

### DIFF
--- a/exporter/mackerelotlpexporter/factory.go
+++ b/exporter/mackerelotlpexporter/factory.go
@@ -37,7 +37,7 @@ func createDefaultConfig() component.Config {
 	queueBatchConfig.Sizer = exporterhelper.RequestSizerTypeBytes
 	queueBatchConfig.MaxSize = defaultBatchMaxSizeBytes
 
-	queueConfig.Batch = configoptional.Default(*queueBatchConfig)
+	queueConfig.Batch = configoptional.Some(*queueBatchConfig)
 
 	return &Config{
 		// overrides default exporter timeout config

--- a/exporter/mackerelotlpexporter/factory_test.go
+++ b/exporter/mackerelotlpexporter/factory_test.go
@@ -5,7 +5,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -14,4 +16,12 @@ func TestCreateDefaultConfig(t *testing.T) {
 
 	cfg := defaultConfig.(*Config)
 	assert.Equal(t, 10*time.Second, cfg.TimeoutConfig.Timeout)
+
+	queueCfg := cfg.QueueConfig
+	assert.True(t, queueCfg.Enabled)
+
+	batchCfg := queueCfg.Batch.Get()
+	require.NotNil(t, batchCfg)
+	assert.Equal(t, int64(5_000_000), batchCfg.MaxSize)
+	assert.Equal(t, exporterhelper.RequestSizerTypeBytes, batchCfg.Sizer)
 }


### PR DESCRIPTION
mackerelotlp exporter has default batch settings, but these were not being applied correctly.

The cause is a mix-up between [`configoptional.Some`](https://pkg.go.dev/go.opentelemetry.io/collector/config/configoptional#Some) and [`configoptional.Default`](https://pkg.go.dev/go.opentelemetry.io/collector/config/configoptional#Default). When using `Default` for configuration, the default setting value will not be applied unless configured as follows:

```yaml
mackerelotlp:
  batch: {}
```

The mackerelotlp exporter is expected to apply batch settings without requiring an object to be passed, as described above.

## Test

### Before

```console
$ docker run -e MACKEREL_API_KEY=111 mackerel/otelcol-mackerel:0.5.0 --config mackerel:default print-config --feature-gates otelcol.printInitialConfig | yq .exporters.mackerelotlp.sending_queue
batch: null
block_on_overflow: false
enabled: true
num_consumers: 10
queue_size: 1000
sizer: {}
storage: null
wait_for_result: false
```

### After

```console
$ docker run -e MACKEREL_API_KEY=111 mackerel/otelcol-mackerel:0.0.0-SNAPSHOT-8e4e093-arm64 --config mackerel:default print-config --feature-gates otelcol.printInitialConfig | yq .exporters.mackerelotlp.sending_queue
batch:
  flush_timeout: 200ms
  max_size: 5000000
  min_size: 8192
  sizer: {}
block_on_overflow: false
enabled: true
num_consumers: 10
queue_size: 1000
sizer: {}
storage: null
wait_for_result: false
```