### PR TITLE
fix(deps): Upgrade the container base image to Debian 13

### DIFF
--- a/distributions/otelcol-mackerel/Dockerfile
+++ b/distributions/otelcol-mackerel/Dockerfile
@@ -1,7 +1,7 @@
 # Build with GoReleaser
 # cf.) https://goreleaser.com/customization/dockers_v2/
 
-FROM gcr.io/distroless/base-debian12:nonroot
+FROM gcr.io/distroless/base-debian13:nonroot
 
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
The distroless Debian 13 image is now for general use.

- https://github.com/GoogleContainerTools/distroless/pull/1942

We upgrade the Docker base image for otelcol-mackerel to Debian 13.

## Test

```console
$ docker run -e MACKEREL_API_KEY=111 mackerel/otelcol-mackerel:0.0.0-SNAPSHOT-6e20f05-arm64
2025-12-18T12:46:03.609Z        info    builders/builders.go:26 Development component. May change in the future.       {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "otelcol.component.id": "mackerelotlp", "otelcol.component.kind": "exporter", "otelcol.signal": "traces"}
2025-12-18T12:46:03.609Z        info    builders/builders.go:26 Development component. May change in the future.       {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "otelcol.component.id": "mackerelotlp", "otelcol.component.kind": "exporter", "otelcol.signal": "metrics"}
2025-12-18T12:46:03.610Z        info    service@v0.141.0/service.go:224 Starting otelcol-mackerel...    {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "Version": "0.5.0", "NumCPU": 14}
2025-12-18T12:46:03.610Z        info    extensions/extensions.go:40     Starting extensions...  {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}}
2025-12-18T12:46:03.611Z        info    internal/resourcedetection.go:137       began detecting resource information   {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "otelcol.component.id": "resourcedetection", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "metrics", "otelcol.signal": "metrics"}
2025-12-18T12:46:03.611Z        info    internal/resourcedetection.go:188       detected resource information   {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "otelcol.component.id": "resourcedetection", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "metrics", "otelcol.signal": "metrics", "resource": {"host.name":"e7619a4e2770","os.type":"linux"}}
2025-12-18T12:46:03.612Z        info    otlpreceiver@v0.141.0/otlp.go:120       Starting GRPC server    {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "otelcol.component.id": "otlp", "otelcol.component.kind": "receiver", "endpoint": "127.0.0.1:4317"}
2025-12-18T12:46:03.612Z        info    otlpreceiver@v0.141.0/otlp.go:178       Starting HTTP server    {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}, "otelcol.component.id": "otlp", "otelcol.component.kind": "receiver", "endpoint": "127.0.0.1:4318"}
2025-12-18T12:46:03.612Z        info    service@v0.141.0/service.go:247 Everything is ready. Begin running and processing data. {"resource": {"service.instance.id": "1038384f-66ff-407f-a34c-1b566e35b4e8", "service.name": "otelcol-mackerel", "service.version": "0.5.0"}}
```

