### PR TITLE
chore: update the go directive with Renovate, only in the root module

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       ],
       "groupName": "opentelemetry-collector upstream dependencies",
       "labels": ["upgrade-otelcol-libs"]
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "matchFileNames": ["go.mod"],
+      "rangeStrategy": "bump"
     }
   ],
   "postUpdateOptions": ["gomodTidy"]


### PR DESCRIPTION
In CI, the Go version to install is determined by reading the toolchain directive and go directive from go.mod.

However, in the root module, the go directive required by a dependent tool is too new, so we cannot use the toolchain directive (it is removed when running go mod tidy).

- cf.) https://github.com/mackerelio/opentelemetry-collector-mackerel/pull/71/files

In addition, with Renovate’s default configuration, only the toolchain directive is updated. As a result of these overlapping constraints, we are currently unable to maintain the Go version used for builds via Renovate.

Therefore, we add an explicit Renovate configuration to update the go directive. This applies only to the root module. If the go directive were updated in submodules as well, the components we provide would no longer be buildable with older stable Go versions.