### PR TITLE
fix ci

### DIFF
--- a/confmap/provider/zerocfgprovider/testdata/00_default_config.yaml
+++ b/confmap/provider/zerocfgprovider/testdata/00_default_config.yaml
@@ -24,5 +24,5 @@ service:
       exporters: [mackerel_otlp]
     logs:
       receivers: [otlp]
-      processors: [resourcedetection]
+      processors: [resource_detection]
       exporters: [mackerel_otlp]

--- a/confmap/provider/zerocfgprovider/testdata/01_with_otelcol_host_config.yaml
+++ b/confmap/provider/zerocfgprovider/testdata/01_with_otelcol_host_config.yaml
@@ -24,5 +24,5 @@ service:
       exporters: [mackerel_otlp]
     logs:
       receivers: [otlp]
-      processors: [resourcedetection]
+      processors: [resource_detection]
       exporters: [mackerel_otlp]

--- a/confmap/provider/zerocfgprovider/testdata/02_with_otelcol_sampling_config.yaml
+++ b/confmap/provider/zerocfgprovider/testdata/02_with_otelcol_sampling_config.yaml
@@ -26,5 +26,5 @@ service:
       exporters: [mackerel_otlp]
     logs:
       receivers: [otlp]
-      processors: [resourcedetection]
+      processors: [resource_detection]
       exporters: [mackerel_otlp]


### PR DESCRIPTION
https://github.com/mackerelio/opentelemetry-collector-mackerel/pull/155 で追加されたテストが、https://github.com/mackerelio/opentelemetry-collector-mackerel/pull/146 で変更された `resourcedetection` -> `resource_detection` の変更を反映していなかったのを修正