### PR TITLE
replace gRPC IPv4 resolver with custom resolver method

### DIFF
--- a/exporter/mackerelotlpexporter/export.go
+++ b/exporter/mackerelotlpexporter/export.go
@@ -3,8 +3,6 @@ package mackerelotlpexporter
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net"
 	"os"
 
 	"go.opentelemetry.io/collector/component"
@@ -43,17 +41,12 @@ func createMetrics(ctx context.Context, set exporter.Settings, cfg component.Con
 	otlpCfg.ClientConfig.Headers = configopaque.MapList{
 		{Name: "Mackerel-Api-Key", Value: mackerelApiKey},
 	}
-	// IPv4 resolution targets only metricsEndpoint because it is the only gRPC endpoint.
 	metricsEndpoint := mackerelOTLPCfg.MetricsEndpoint
 	if os.Getenv("OTELCOL_MACKEREL_PREFER_IPV4") != "" {
-		resolved, originalHostPort, err := resolveIPv4(ctx, metricsEndpoint)
-		if err != nil {
-			return nil, err
-		}
-		metricsEndpoint = resolved
-		if originalHostPort != "" {
-			otlpCfg.ClientConfig.Authority = originalHostPort
-		}
+		// Use the custom ipv4:/// resolver scheme so gRPC re-resolves on connection failure.
+		// gRPC derives :authority and TLS SNI from the endpoint portion of the URI,
+		// so the original hostname is preserved without setting Authority explicitly.
+		metricsEndpoint = ipv4ResolverScheme + ":///" + metricsEndpoint
 	}
 	otlpCfg.ClientConfig.Endpoint = metricsEndpoint
 	otlpCfg.ClientConfig.Compression = "gzip"
@@ -148,24 +141,3 @@ func createLogs(ctx context.Context, set exporter.Settings, cfg component.Config
 	return exp, nil
 }
 
-// resolveIPv4 resolves the host in endpoint to an IPv4 address.
-// Returns the resolved endpoint and the original host:port.
-// If the host is already an IP address, it returns the endpoint unchanged.
-// Returns an error if the endpoint cannot be parsed as host:port.
-func resolveIPv4(ctx context.Context, endpoint string) (string, string, error) {
-	host, port, err := net.SplitHostPort(endpoint)
-	if err != nil {
-		return "", "", fmt.Errorf("parse endpoint %q: %w", endpoint, err)
-	}
-	if net.ParseIP(host) != nil {
-		return endpoint, "", nil
-	}
-	ips, err := net.DefaultResolver.LookupIP(ctx, "ip4", host)
-	if err != nil {
-		return "", "", fmt.Errorf("resolve %s to IPv4: %w", host, err)
-	}
-	if len(ips) == 0 {
-		return "", "", fmt.Errorf("no IPv4 address found for %s", host)
-	}
-	return net.JoinHostPort(ips[0].String(), port), endpoint, nil
-}

--- a/exporter/mackerelotlpexporter/export.go
+++ b/exporter/mackerelotlpexporter/export.go
@@ -43,7 +43,7 @@ func createMetrics(ctx context.Context, set exporter.Settings, cfg component.Con
 	}
 	metricsEndpoint := mackerelOTLPCfg.MetricsEndpoint
 	if os.Getenv("OTELCOL_MACKEREL_PREFER_IPV4") != "" {
-		// Use the custom ipv4:/// resolver scheme so gRPC re-resolves on connection failure.
+		// Use the custom mdotipv4:/// resolver scheme so gRPC re-resolves on connection failure.
 		// gRPC derives :authority and TLS SNI from the endpoint portion of the URI,
 		// so the original hostname is preserved without setting Authority explicitly.
 		metricsEndpoint = ipv4ResolverScheme + ":///" + metricsEndpoint

--- a/exporter/mackerelotlpexporter/export_test.go
+++ b/exporter/mackerelotlpexporter/export_test.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
 )
 
 type mockMetricsReceiver struct {
@@ -165,65 +167,99 @@ func TestSendLogs(t *testing.T) {
 	assert.Equal(t, int64(1), requestsCounter.Load())
 }
 
-func TestResolveIPv4(t *testing.T) {
+func TestIPv4Resolver(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name             string
-		endpoint         string
-		wantOriginalAddr string
-		wantIPv4         bool
-		wantErr          bool
+		name          string
+		endpoint      string
+		wantIPv4      bool
+		wantBuildErr  bool
+		wantLookupErr bool
 	}{
 		{
-			name:             "hostname is resolved to IPv4",
-			endpoint:         "localhost:4317",
-			wantOriginalAddr: "localhost:4317",
-			wantIPv4:         true,
+			name:     "hostname is resolved to IPv4",
+			endpoint: "localhost:4317",
+			wantIPv4: true,
 		},
 		{
-			name:             "IP address is returned unchanged",
-			endpoint:         "127.0.0.1:4317",
-			wantOriginalAddr: "",
-			wantIPv4:         false,
+			name:     "IP address is returned unchanged",
+			endpoint: "127.0.0.1:4317",
 		},
 		{
-			name:             "IPv6 address is returned unchanged",
-			endpoint:         "[::1]:4317",
-			wantOriginalAddr: "",
-			wantIPv4:         false,
+			name:     "IPv6 address is returned unchanged",
+			endpoint: "[::1]:4317",
 		},
 		{
-			name:     "no port in endpoint",
-			endpoint: "localhost",
-			wantErr:  true,
+			name:         "no port in endpoint",
+			endpoint:     "localhost",
+			wantBuildErr: true,
 		},
 		{
-			name:     "unresolvable hostname",
-			endpoint: "unresolvable.invalid:4317",
-			wantErr:  true,
+			name:          "unresolvable hostname",
+			endpoint:      "unresolvable.invalid:4317",
+			wantLookupErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			resolved, originalAddr, err := resolveIPv4(t.Context(), tt.endpoint)
-			if tt.wantErr {
+
+			cc := &testResolverClientConn{}
+			target := resolver.Target{}
+			target.URL.Scheme = ipv4ResolverScheme
+			target.URL.Path = "/" + tt.endpoint
+
+			builder := &ipv4ResolverBuilder{}
+			r, err := builder.Build(target, cc, resolver.BuildOptions{})
+			if tt.wantBuildErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantOriginalAddr, originalAddr)
+			defer r.Close()
+
+			if tt.wantLookupErr {
+				require.Error(t, cc.err)
+				return
+			}
+
+			require.NoError(t, cc.err)
+			require.NotEmpty(t, cc.state.Addresses)
+
 			if tt.wantIPv4 {
-				host, _, err := net.SplitHostPort(resolved)
-				require.NoError(t, err)
-				ip := net.ParseIP(host)
-				require.NotNil(t, ip)
-				assert.NotNil(t, ip.To4(), "expected IPv4 address, got %s", host)
+				for _, addr := range cc.state.Addresses {
+					host, _, err := net.SplitHostPort(addr.Addr)
+					require.NoError(t, err)
+					ip := net.ParseIP(host)
+					require.NotNil(t, ip)
+					assert.NotNil(t, ip.To4(), "expected IPv4 address, got %s", host)
+				}
 			} else {
-				assert.Equal(t, tt.endpoint, resolved)
+				assert.Equal(t, tt.endpoint, cc.state.Addresses[0].Addr)
 			}
 		})
 	}
+}
+
+type testResolverClientConn struct {
+	state resolver.State
+	err   error
+}
+
+func (cc *testResolverClientConn) UpdateState(state resolver.State) error {
+	cc.state = state
+	cc.err = nil
+	return nil
+}
+
+func (cc *testResolverClientConn) ReportError(err error) {
+	cc.err = err
+}
+
+func (cc *testResolverClientConn) NewAddress([]resolver.Address) {}
+
+func (cc *testResolverClientConn) ParseServiceConfig(string) *serviceconfig.ParseResult {
+	return nil
 }

--- a/exporter/mackerelotlpexporter/export_test.go
+++ b/exporter/mackerelotlpexporter/export_test.go
@@ -2,12 +2,14 @@ package mackerelotlpexporter
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -171,16 +173,20 @@ func TestIPv4Resolver(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		endpoint      string
-		wantIPv4      bool
-		wantBuildErr  bool
-		wantLookupErr bool
+		name           string
+		endpoint       string
+		wantIPv4       bool
+		wantBuildErr   bool
+		wantLookupErr  bool
+		lookupErr      error
+		lookupIPs      []net.IP
+		updateStateErr error
 	}{
 		{
-			name:     "hostname is resolved to IPv4",
-			endpoint: "localhost:4317",
-			wantIPv4: true,
+			name:      "hostname is resolved to IPv4",
+			endpoint:  "localhost:4317",
+			wantIPv4:  true,
+			lookupIPs: []net.IP{net.ParseIP("127.0.0.1")},
 		},
 		{
 			name:     "IP address is returned unchanged",
@@ -199,6 +205,14 @@ func TestIPv4Resolver(t *testing.T) {
 			name:          "unresolvable hostname",
 			endpoint:      "unresolvable.invalid:4317",
 			wantLookupErr: true,
+			lookupErr:     errors.New("lookup failed"),
+		},
+		{
+			name:           "update state error",
+			endpoint:       "stateerr.invalid:4317",
+			wantLookupErr:  true,
+			lookupIPs:      []net.IP{net.ParseIP("127.0.0.2")},
+			updateStateErr: errors.New("update state failed"),
 		},
 	}
 
@@ -206,12 +220,22 @@ func TestIPv4Resolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			cc := &testResolverClientConn{}
+			cc := &testResolverClientConn{updateStateErr: tt.updateStateErr}
 			target := resolver.Target{}
 			target.URL.Scheme = ipv4ResolverScheme
 			target.URL.Path = "/" + tt.endpoint
 
-			builder := &ipv4ResolverBuilder{}
+			builder := &ipv4ResolverBuilder{
+				lookupIP: func(context.Context, string, string) ([]net.IP, error) {
+					if tt.lookupErr != nil {
+						return nil, tt.lookupErr
+					}
+					if tt.lookupIPs != nil {
+						return tt.lookupIPs, nil
+					}
+					return []net.IP{net.ParseIP("127.0.0.1")}, nil
+				},
+			}
 			r, err := builder.Build(target, cc, resolver.BuildOptions{})
 			if tt.wantBuildErr {
 				require.Error(t, err)
@@ -243,12 +267,45 @@ func TestIPv4Resolver(t *testing.T) {
 	}
 }
 
+func TestIPv4ResolverResolveNowReResolve(t *testing.T) {
+	t.Parallel()
+
+	cc := &testResolverClientConn{}
+	target := resolver.Target{}
+	target.URL.Scheme = ipv4ResolverScheme
+	target.URL.Path = "/example.invalid:4317"
+
+	var lookupCount atomic.Int64
+	builder := &ipv4ResolverBuilder{
+		resolveInterval: 10 * time.Millisecond,
+		lookupIP: func(context.Context, string, string) ([]net.IP, error) {
+			lookupCount.Add(1)
+			return []net.IP{net.ParseIP("127.0.0.1")}, nil
+		},
+	}
+
+	r, err := builder.Build(target, cc, resolver.BuildOptions{})
+	require.NoError(t, err)
+	defer r.Close()
+
+	before := lookupCount.Load()
+	r.ResolveNow(resolver.ResolveNowOptions{})
+	require.Eventually(t, func() bool {
+		return lookupCount.Load() > before
+	}, time.Second, 5*time.Millisecond)
+}
+
 type testResolverClientConn struct {
-	state resolver.State
-	err   error
+	state          resolver.State
+	err            error
+	updateStateErr error
 }
 
 func (cc *testResolverClientConn) UpdateState(state resolver.State) error {
+	if cc.updateStateErr != nil {
+		cc.err = cc.updateStateErr
+		return cc.updateStateErr
+	}
 	cc.state = state
 	cc.err = nil
 	return nil

--- a/exporter/mackerelotlpexporter/ipv4resolver.go
+++ b/exporter/mackerelotlpexporter/ipv4resolver.go
@@ -1,0 +1,117 @@
+package mackerelotlpexporter
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/resolver"
+)
+
+const ipv4ResolverScheme = "ipv4"
+
+const minResolveInterval = 30 * time.Second
+
+func init() {
+	resolver.Register(&ipv4ResolverBuilder{})
+}
+
+type ipv4ResolverBuilder struct{}
+
+func (b *ipv4ResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
+	endpoint := target.Endpoint()
+	host, port, err := net.SplitHostPort(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("ipv4 resolver: parse endpoint %q: %w", endpoint, err)
+	}
+
+	if net.ParseIP(host) != nil {
+		cc.UpdateState(resolver.State{
+			Addresses: []resolver.Address{{Addr: endpoint}},
+		})
+		return &deadResolver{}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	r := &ipv4Resolver{
+		host:   host,
+		port:   port,
+		ctx:    ctx,
+		cancel: cancel,
+		cc:     cc,
+		rn:     make(chan struct{}, 1),
+	}
+	r.lookup()
+	r.wg.Add(1)
+	go r.watcher()
+	return r, nil
+}
+
+func (b *ipv4ResolverBuilder) Scheme() string {
+	return ipv4ResolverScheme
+}
+
+type deadResolver struct{}
+
+func (deadResolver) ResolveNow(resolver.ResolveNowOptions) {}
+func (deadResolver) Close()                                {}
+
+type ipv4Resolver struct {
+	host   string
+	port   string
+	ctx    context.Context
+	cancel context.CancelFunc
+	cc     resolver.ClientConn
+	rn     chan struct{}
+	wg     sync.WaitGroup
+}
+
+// watcher re-resolves on ResolveNow signals, enforcing a minimum interval.
+func (r *ipv4Resolver) watcher() {
+	defer r.wg.Done()
+	for {
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-r.rn:
+		}
+		select {
+		case <-r.ctx.Done():
+			return
+		case <-time.After(minResolveInterval):
+		}
+		r.lookup()
+	}
+}
+
+func (r *ipv4Resolver) lookup() {
+	ips, err := net.DefaultResolver.LookupIP(r.ctx, "ip4", r.host)
+	if err != nil {
+		r.cc.ReportError(fmt.Errorf("ipv4 resolver: resolve %s: %w", r.host, err))
+		return
+	}
+	if len(ips) == 0 {
+		r.cc.ReportError(fmt.Errorf("ipv4 resolver: no IPv4 address found for %s", r.host))
+		return
+	}
+
+	addrs := make([]resolver.Address, len(ips))
+	for i, ip := range ips {
+		addrs[i] = resolver.Address{Addr: net.JoinHostPort(ip.String(), r.port)}
+	}
+	r.cc.UpdateState(resolver.State{Addresses: addrs})
+}
+
+func (r *ipv4Resolver) ResolveNow(resolver.ResolveNowOptions) {
+	select {
+	case r.rn <- struct{}{}:
+	default:
+	}
+}
+
+func (r *ipv4Resolver) Close() {
+	r.cancel()
+	r.wg.Wait()
+}

--- a/exporter/mackerelotlpexporter/ipv4resolver.go
+++ b/exporter/mackerelotlpexporter/ipv4resolver.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/resolver"
 )
 
-const ipv4ResolverScheme = "ipv4"
+const ipv4ResolverScheme = "mdotipv4"
 
 var minResolveInterval = 30 * time.Second
 

--- a/exporter/mackerelotlpexporter/ipv4resolver.go
+++ b/exporter/mackerelotlpexporter/ipv4resolver.go
@@ -12,13 +12,18 @@ import (
 
 const ipv4ResolverScheme = "ipv4"
 
-const minResolveInterval = 30 * time.Second
+var minResolveInterval = 30 * time.Second
 
 func init() {
 	resolver.Register(&ipv4ResolverBuilder{})
 }
 
-type ipv4ResolverBuilder struct{}
+type lookupIPFunc func(ctx context.Context, network, host string) ([]net.IP, error)
+
+type ipv4ResolverBuilder struct {
+	lookupIP        lookupIPFunc
+	resolveInterval time.Duration
+}
 
 func (b *ipv4ResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
 	endpoint := target.Endpoint()
@@ -28,20 +33,35 @@ func (b *ipv4ResolverBuilder) Build(target resolver.Target, cc resolver.ClientCo
 	}
 
 	if net.ParseIP(host) != nil {
-		cc.UpdateState(resolver.State{
+		if err := cc.UpdateState(resolver.State{
 			Addresses: []resolver.Address{{Addr: endpoint}},
-		})
+		}); err != nil {
+			return nil, fmt.Errorf("ipv4 resolver: update state for endpoint %q: %w", endpoint, err)
+		}
 		return &deadResolver{}, nil
+	}
+
+	lookupIP := b.lookupIP
+	if lookupIP == nil {
+		lookupIP = net.DefaultResolver.LookupIP
+	}
+
+	resolveInterval := b.resolveInterval
+	if resolveInterval <= 0 {
+		resolveInterval = minResolveInterval
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &ipv4Resolver{
-		host:   host,
-		port:   port,
-		ctx:    ctx,
-		cancel: cancel,
-		cc:     cc,
-		rn:     make(chan struct{}, 1),
+		host:       host,
+		port:       port,
+		ctx:        ctx,
+		cancel:     cancel,
+		cc:         cc,
+		rn:         make(chan struct{}, 1),
+		lookupIP:   lookupIP,
+		interval:   resolveInterval,
+		lastLookup: time.Now(),
 	}
 	r.lookup()
 	r.wg.Add(1)
@@ -59,13 +79,16 @@ func (deadResolver) ResolveNow(resolver.ResolveNowOptions) {}
 func (deadResolver) Close()                                {}
 
 type ipv4Resolver struct {
-	host   string
-	port   string
-	ctx    context.Context
-	cancel context.CancelFunc
-	cc     resolver.ClientConn
-	rn     chan struct{}
-	wg     sync.WaitGroup
+	host       string
+	port       string
+	ctx        context.Context
+	cancel     context.CancelFunc
+	cc         resolver.ClientConn
+	rn         chan struct{}
+	lookupIP   lookupIPFunc
+	interval   time.Duration
+	lastLookup time.Time
+	wg         sync.WaitGroup
 }
 
 // watcher re-resolves on ResolveNow signals, enforcing a minimum interval.
@@ -77,17 +100,21 @@ func (r *ipv4Resolver) watcher() {
 			return
 		case <-r.rn:
 		}
-		select {
-		case <-r.ctx.Done():
-			return
-		case <-time.After(minResolveInterval):
+		nextAllowed := r.lastLookup.Add(r.interval)
+		if delay := time.Until(nextAllowed); delay > 0 {
+			select {
+			case <-r.ctx.Done():
+				return
+			case <-time.After(delay):
+			}
 		}
 		r.lookup()
+		r.lastLookup = time.Now()
 	}
 }
 
 func (r *ipv4Resolver) lookup() {
-	ips, err := net.DefaultResolver.LookupIP(r.ctx, "ip4", r.host)
+	ips, err := r.lookupIP(r.ctx, "ip4", r.host)
 	if err != nil {
 		r.cc.ReportError(fmt.Errorf("ipv4 resolver: resolve %s: %w", r.host, err))
 		return
@@ -101,7 +128,9 @@ func (r *ipv4Resolver) lookup() {
 	for i, ip := range ips {
 		addrs[i] = resolver.Address{Addr: net.JoinHostPort(ip.String(), r.port)}
 	}
-	r.cc.UpdateState(resolver.State{Addresses: addrs})
+	if err := r.cc.UpdateState(resolver.State{Addresses: addrs}); err != nil {
+		r.cc.ReportError(fmt.Errorf("ipv4 resolver: update state for %s: %w", r.host, err))
+	}
 }
 
 func (r *ipv4Resolver) ResolveNow(resolver.ResolveNowOptions) {


### PR DESCRIPTION
#173 に対応した修正です。

`OTELCOL_MACKEREL_PREFER_IPV4` 有効時の IPv4 アドレス解決を、起動時の一括解決（`resolveIPv4` 関数）からgRPC カスタムネームリゾルバ方式に変更します。
従来の `resolveIPv4` は exporter 生成時に1回だけ DNS を引き、解決済みの IP アドレスをエンドポイントとして渡していましたが、この方式では以下の問題がありました。

- **DNS 変更に追従できない**: 起動後にサーバーの IP アドレスが変わっても、旧アドレスが到達不能になるまで気づかない
- **gRPC の再接続機構と統合できない**: gRPC は接続失敗時にリゾルバに再解決を要求する（`ResolveNow`）が、IP 直指定では再解決が意味をなさない

そのため、以下の対処を行います。

- `ipv4` スキームの gRPC カスタムリゾルバ（`resolver.Builder` / `resolver.Resolver`）を実装し、`init()` でグローバル登録
- `OTELCOL_MACKEREL_PREFER_IPV4` 有効時、エンドポイントを `ipv4:///host:port` 形式に変換（従来の `resolveIPv4` 関数は削除）
- gRPC が URI の endpoint 部分からホスト名を取得するため、TLS SNI / `:authority` ヘッダは明示的な設定なしで正しく動作する

最低再解決インターバルは30秒としています。これは、grpc-go の組み込み DNS リゾルバ（`dns:///`）の `MinResolutionInterval`（30秒）に合わせています。
https://github.com/grpc/grpc-go/blob/master/internal/resolver/dns/dns_resolver.go

Linux実機で実行を確認し、実行中に一部のIPアドレスを塞いでも別のアドレスにフォールバックして投稿されることを確認済みです。

--
in English

This fix addresses #173 

When `OTELCOL_MACKEREL_PREFER_IPV4` is enabled, IPv4 address resolution has been changed from batch resolution at startup (via the `resolveIPv4` function) to a gRPC custom name resolver approach.

Previously, `resolveIPv4` resolved DNS only once when creating the exporter and passed the resolved IP address as the endpoint. However, this approach had the following issues:

- Unable to track DNS changes: If the server's IP address changes after startup, it won't be detected until the old address becomes unreachable.
- Incompatible with gRPC's reconnection mechanism: gRPC requests re-resolution from the resolver upon connection failure (`ResolveNow`), but specifying an IP address directly makes re-resolution ineffective.

To address these issues, the following changes have been made:

- Implemented a custom gRPC resolver (`resolver.Builder` / `resolver.Resolver`) for the `ipv4` scheme and registered it globally in `init()`.
- When `OTELCOL_MACKEREL_PREFER_IPV4` is enabled, the endpoint is now converted to the `ipv4:///host:port` format (the old `resolveIPv4` function has been removed).
- Since gRPC extracts the hostname from the endpoint portion of the URI, TLS SNI and the `:authority` header work correctly without explicit configuration.

The minimum re-resolution interval is set to 30 seconds. This matches `MinResolutionInterval` (30s) in grpc-go's built-in DNS resolver (`dns:///`).
https://github.com/grpc/grpc-go/blob/master/internal/resolver/dns/dns_resolver.go

Verified on an actual Linux machine that even if some IP addresses are blocked while running, it falls back to another address and continues sending data successfully.