### PR TITLE
add Forward Connector

### DIFF
--- a/distributions/otelcol-mackerel/README.ja.md
+++ b/distributions/otelcol-mackerel/README.ja.md
@@ -217,8 +217,9 @@ OpenTelemetry コミュニティが提供する OpenTelemetry コレクターコ
 
 ### コネクター
 
-| コンポーネント | 説明                    | ドキュメント                                                                                                            |
-| -------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `routing`      | Routing Connector       | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)      |
+| コンポーネント  | 説明                    | ドキュメント                                                                                                            |
+| --------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `forward`       | Forward Connector       | [Document](https://github.com/open-telemetry/opentelemetry-collector/tree/main/connector/forwardconnector)              |
+| `routing`       | Routing Connector       | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)      |
 | `service_graph` | Service Graph Connector | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/servicegraphconnector) |
 | `span_metrics`  | Span Metrics Connector  | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector)  |

--- a/distributions/otelcol-mackerel/README.md
+++ b/distributions/otelcol-mackerel/README.md
@@ -217,8 +217,9 @@ If you are a Mackerel user and would like to add OpenTelemetry Collector compone
 
 ### Connectors
 
-| Component      | Description             | Document                                                                                                                |
-| -------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `routing`      | Routing Connector       | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)      |
+| Component       | Description             | Document                                                                                                                |
+| --------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `forward`       | Forward Connector       | [Document](https://github.com/open-telemetry/opentelemetry-collector/tree/main/connector/forwardconnector)              |
+| `routing`       | Routing Connector       | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/routingconnector)      |
 | `service_graph` | Service Graph Connector | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/servicegraphconnector) |
 | `span_metrics`  | Span Metrics Connector  | [Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/spanmetricsconnector)  |

--- a/distributions/otelcol-mackerel/manifest.yaml
+++ b/distributions/otelcol-mackerel/manifest.yaml
@@ -41,6 +41,7 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/syslogreceiver v0.155.0
 
 connectors:
+  - gomod: go.opentelemetry.io/collector/connector/forwardconnector v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/spanmetricsconnector v0.155.0


### PR DESCRIPTION
このPRでは、forwardコネクタを追加します。フィルタリング/サンプリングのヘルプ https://mackerel.io/ja/docs/entry/log/filtering-sampling ではOTel Collector向けに例示していますが、MDOTでも利用できるようにします。

--

This PR adds the `forward` connector. While the filtering/sampling documentation (https://mackerel.io/ja/docs/entry/log/filtering-sampling) provides examples for OTel Collector, this update enables its use in MDOT as well.
